### PR TITLE
Adding pr-num and pr-ref options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Create and update a PR comment, rather than creating a new one with every run.
 | `github-token`       | true        | The GitHub token for interacting with the repository.                       |
 | `comment-identifier` | true        | An unchanging identifier for the comment that should be updated or created. |
 | `comment-content`    | true        | A string of Github-flavored markdown for your comment.                      |
+| `pr-num`             | false\*     | The number for the target PR.                                               |
+| `pr-ref`             | false\*     | A git ref which points to a commit contained in the target PR.              |
+
+**_\* If the workflow containing this action is not running from a `pull_request` or `pull_request_target` event, one of these parameters is required._**
 
 ## Usage Examples
 
@@ -32,7 +36,11 @@ jobs:
       - name: 'Create or Update PR Comment'
         uses: im-open/update-pr-comment@v1.0.8
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-identifier: 'specific-comment-identifier' # this should not change
+          # Optional Inputs
+          # pr-num: 135
+          # pr-ref: ${{ github.ref }}
           comment-content: |
             # Comment Content
 
@@ -73,7 +81,7 @@ its dependencies into a single file located in the `dist` folder.
 
 ### Incrementing the Version
 
-Both the build and PR merge workflows will use the strategies below to determine what the next version will be.  If the build workflow was not able to automatically update the README.md action examples with the next version, the README.md should be updated manually as part of the PR using that calculated version.
+Both the build and PR merge workflows will use the strategies below to determine what the next version will be. If the build workflow was not able to automatically update the README.md action examples with the next version, the README.md should be updated manually as part of the PR using that calculated version.
 
 This action uses [git-version-lite] to examine commit messages to determine whether to perform a major, minor or patch increment on merge. The following table provides the fragment that should be included in a commit message to active different increment strategies.
 | Increment Type | Commit Message Fragment |

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,14 @@ inputs:
     required: true
     description: A string of Github-flavored markdown for your comment
 
+  pr-ref:
+    required: false
+    description: A git ref which points to a commit contained in the target PR
+
+  pr-num:
+    required: false
+    description: The number for the target PR
+
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,9 @@ const octokit = github.getOctokit(token);
 const { repo: contextRepo, payload: githubPaylod } = github.context;
 const { pull_request: pullRequest } = githubPaylod;
 const { owner, repo } = contextRepo;
-const prNumber = pullRequest?.number || 0;
+const inputPrRef = core.getInput('pr-ref', { required: false, trimWhitespace: true });
+const inputPrNum = core.getInput('pr-number', { required: false, trimWhitespace: true });
+const prNumber = parseInt(inputPrNum, 10) || pullRequest?.number || 0;
 
 const commentId = core.getInput('comment-identifier', requiredArgOptions);
 const commentContent = core.getInput('comment-content', requiredArgOptions);
@@ -22,18 +24,18 @@ const commentPackageName = 'im-open/update-pr-comment';
 const commentEnd = '-->';
 const markupPrefix = `${commentStart} ${commentPackageName} - ${commentId} ${commentEnd}`;
 
-async function findExistingComment() {
-  if (!pullRequest) return;
+async function findExistingComment(prNum: number) {
+  if (!prNum) return;
 
   const comments = await octokit.paginate(octokit.rest.issues.listComments, {
     owner,
     repo,
-    issue_number: prNumber,
+    issue_number: prNum,
   });
 
   if (!comments.length) {
     core.info(
-      `An existing comment for ${commentId} was not found on PR #${prNumber}, will create a new one instead.`,
+      `An existing comment for ${commentId} was not found on PR #${prNum}, will create a new one instead.`,
     );
 
     return null;
@@ -42,7 +44,7 @@ async function findExistingComment() {
   const existingComment = comments.find((c) => c.body?.startsWith(markupPrefix));
   if (existingComment) {
     core.info(
-      `An existing comment (${existingComment.id}) for ${commentId} was found on PR #${prNumber} and will be updated.`,
+      `An existing comment (${existingComment.id}) for ${commentId} was found on PR #${prNum} and will be updated.`,
     );
 
     return existingComment.id;
@@ -60,61 +62,84 @@ async function updateComment(body: string, existingCommentId: number) {
   return octokit.rest.issues.updateComment(requestParams);
 }
 
-async function createComment(body: string) {
+async function createComment(body: string, prNum: number) {
   const requestParams = {
     owner,
     repo,
     body,
-    issue_number: prNumber,
+    issue_number: prNum,
   };
 
   return octokit.rest.issues.createComment(requestParams);
 }
 
-async function createOrUpdateComment() {
-  if (!pullRequest) return;
+async function createOrUpdateComment(prNums: number[]) {
+  if (!prNums.length) return;
 
   try {
-    core.info('Checking for existing comment on PR....');
-    const existingCommentId = await findExistingComment();
-    const body = `${markupPrefix}\n${commentContent}`;
-    const successStatus = existingCommentId ? 200 : 201;
-    const infoMessage = existingCommentId
-      ? `Updating existing PR #${existingCommentId} comment...`
-      : 'Creating a new PR comment...';
-    const action = existingCommentId ? 'update' : 'create';
+    prNums.forEach(async (prNum) => {
+      core.info('Checking for existing comment on PR....');
+      const existingCommentId = await findExistingComment(prNum);
+      const body = `${markupPrefix}\n${commentContent}`;
+      const successStatus = existingCommentId ? 200 : 201;
+      const infoMessage = existingCommentId
+        ? `Updating existing PR #${existingCommentId} comment...`
+        : 'Creating a new PR comment...';
+      const action = existingCommentId ? 'update' : 'create';
 
-    core.info(infoMessage);
+      core.info(infoMessage);
 
-    const {
-      status,
-      data: { id: updatedCommentId },
-    } = existingCommentId
-      ? await updateComment(body, existingCommentId as number)
-      : await createComment(body);
+      const {
+        status,
+        data: { id: updatedCommentId },
+      } = existingCommentId
+        ? await updateComment(body, existingCommentId as number)
+        : await createComment(body, prNum);
 
-    if (status === successStatus) {
-      core.info(`PR comment was ${action}d.  ID: ${updatedCommentId}.`);
-    } else {
-      core.setFailed(`Failed to ${action} PR comment. Error code: ${status}.`);
-    }
+      if (status === successStatus) {
+        core.info(`PR comment was ${action}d.  ID: ${updatedCommentId}.`);
+      } else {
+        core.setFailed(`Failed to ${action} PR comment. Error code: ${status}.`);
+      }
+    });
   } catch (error) {
-    core.setFailed(`An error occurred trying to create or update the PR comment: ${error.message}`);
+    core.setFailed(
+      `An error occurred trying to create or update the PR comment: ${(error as Error).message}`,
+    );
   }
 }
 
+async function findPrs() {
+  const prs = await octokit.paginate(octokit.rest.search.issuesAndPullRequests, {
+    q: `${inputPrRef}+repo:${owner}/${repo}+type:pr`,
+  });
+  return prs.map((pr) => pr.number);
+}
+
 async function run() {
-  if (github.context.eventName !== 'pull_request') {
-    core.info(
-      'This event was not triggered by a pull_request.  No comment will be created or updated.',
-    );
-    return;
+  // repo:im-client/frontend-tooling-bff+type:pr+maxversions-2023-01-31-1675192218
+  let prNums = prNumber ? [prNumber] : null;
+  if (!prNums) {
+    if (!inputPrRef) {
+      core.info(
+        'This event was not triggered by a pull_request, and no ref or PR number was supplied.  No comment will be created or updated.',
+      );
+      return;
+    }
+
+    prNums = await findPrs();
+    if (!prNums.length) {
+      core.info(
+        `No PRs were found for the ref ${inputPrRef}.  No comment will be created or updated.`,
+      );
+      return;
+    }
   }
 
   try {
-    await createOrUpdateComment();
+    await createOrUpdateComment(prNums);
   } catch (error) {
-    core.setFailed(`An error occurred processing the summary file: ${error.message}`);
+    core.setFailed(`An error occurred processing the summary file: ${(error as Error).message}`);
   }
 }
 


### PR DESCRIPTION
Adds the option to provide either a `pr-num` or `pr-ref` target as input parameters.

## PR Requirements
- [ ] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [ ] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
