### PR TITLE
ITHD-204625: Create Major version tag on merge

### DIFF
--- a/.github/workflows/increment-version-on-merge.yml
+++ b/.github/workflows/increment-version-on-merge.yml
@@ -57,4 +57,3 @@ jobs:
           sha: ${{ steps.version.outputs.NEXT_VERSION_SHA }}
           source-tag: ${{ steps.version.outputs.NEXT_VERSION }}
           include-major: true
-          include-latest: true

--- a/.github/workflows/increment-version-on-merge.yml
+++ b/.github/workflows/increment-version-on-merge.yml
@@ -43,8 +43,18 @@ jobs:
       # See https://github.com/im-open/git-version-lite for more details around how to increment
       # major/minor/patch through commit messages
       - name: Increment the version
-        uses: im-open/git-version-lite@v2.1.2
+        uses: im-open/git-version-lite@v2
+        id: version
         with:
           create-ref: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           default-release-type: major
+
+      - name: Create Major and Latest Tags
+        uses: im-open/create-tags-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          sha: ${{ steps.version.outputs.NEXT_VERSION_SHA }}
+          source-tag: ${{ steps.version.outputs.NEXT_VERSION }}
+          include-major: true
+          include-latest: true


### PR DESCRIPTION
https://jira.extendhealth.com/servicedesk/customer/portal/26/ITHD-204625

# Summary of PR changes
Allow the creation of a major tag adjacent to the normal major + minor + patch release creation.

This allows downstream workflows to reference the major version instead of the specific minor + patch. Doing so will reduce dependabot alerts and unnecessary PRs to get the latest minor versions.

This is similar to the same pattern used with GitHub Actions.
https://github.com/actions/toolkit/blob/main/docs/action-versioning.md#recommendations

As an example, release `v1.2.3` is created with an accompanying `v1` tag.  Downstream consumers of this repo can reference `v1` instead of `v1.2.3`.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
