### PR TITLE
Optionally create a comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Create and update a PR comment, rather than creating a new one with every run.
 | `comment-content`    | true        | A string of Github-flavored markdown for your comment.                      |
 | `pr-num`             | false\*     | The number for the target PR.                                               |
 | `pr-ref`             | false\*     | A git ref which points to a commit contained in the target PR.              |
+| `create-if-not-exists` | false.    | If comment does not already exists, create it. Defaults to `true`           |
 
 **_\* If the workflow containing this action is not running from a `pull_request` or `pull_request_target` event, one of these parameters is required._**
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ jobs:
 
       - name: 'Create or Update PR Comment'
         # You may also reference just the major or major.minor version.
-        uses: im-open/update-pr-comment@v1.1.1
+        uses: im-open/update-pr-comment@v1.1.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-identifier: 'specific-comment-identifier' # this should not change

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Create and update a PR comment, rather than creating a new one with every run.
 | `comment-content`    | true        | A string of Github-flavored markdown for your comment.                      |
 | `pr-num`             | false\*     | The number for the target PR.                                               |
 | `pr-ref`             | false\*     | A git ref which points to a commit contained in the target PR.              |
-| `create-if-not-exists` | false.    | If comment does not already exists, create it. Defaults to `true`           |
+| `create-if-not-exists` | false.    | If comment does not already exist, create it. Defaults to `true`           |
 
 **_\* If the workflow containing this action is not running from a `pull_request` or `pull_request_target` event, one of these parameters is required._**
 

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
     
   create-if-not-exists:
     required: false
-    description: If commit does not already exists, create it
+    description: If comment does not already exists, create it
     default: 'true'
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,11 @@ inputs:
   pr-num:
     required: false
     description: The number for the target PR
+    
+  create-if-not-exists:
+    required: false
+    description: If commit does not already exists, create it
+    default: 'true'
 
 runs:
   using: 'node16'

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
     
   create-if-not-exists:
     required: false
-    description: If comment does not already exists, create it
+    description: If comment does not already exist, create it
     default: 'true'
 
 runs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -7550,7 +7550,6 @@ function createOrUpdateComment(prNums) {
           import_core.default.info("Comment will not be created.");
           return;
         }
-        existingCommentId ? import_core.default.info("Comment will be updated.") : import_core.default.info("Comment will be createed.");
         const body = `${markupPrefix}
 ${commentContent}`;
         const successStatus = existingCommentId ? 200 : 201;

--- a/dist/index.js
+++ b/dist/index.js
@@ -7488,6 +7488,7 @@ var inputPrNum = import_core.default.getInput("pr-number", { required: false, tr
 var prNumber = parseInt(inputPrNum, 10) || (pullRequest == null ? void 0 : pullRequest.number) || 0;
 var commentId = import_core.default.getInput("comment-identifier", requiredArgOptions);
 var commentContent = import_core.default.getInput("comment-content", requiredArgOptions);
+var createIfNotExists = import_core.default.getBooleanInput("comment-content") || true;
 var commentStart = "<!--";
 var commentPackageName = "im-open/update-pr-comment";
 var commentEnd = "-->";
@@ -7545,6 +7546,10 @@ function createOrUpdateComment(prNums) {
       prNums.forEach((prNum) => __async(this, null, function* () {
         import_core.default.info("Checking for existing comment on PR....");
         const existingCommentId = yield findExistingComment(prNum);
+        if (!createIfNotExists && !existingCommentId) {
+          import_core.default.info("Comment does not exist and will not be created");
+          return;
+        }
         const body = `${markupPrefix}
 ${commentContent}`;
         const successStatus = existingCommentId ? 200 : 201;

--- a/dist/index.js
+++ b/dist/index.js
@@ -7503,7 +7503,7 @@ function findExistingComment(prNum) {
       issue_number: prNum
     });
     if (!comments.length) {
-      import_core.default.info(`An existing comment for ${commentId} was not found on PR #${prNum}, will create a new one instead.`);
+      import_core.default.info(`An existing comment for ${commentId} was not found on PR #${prNum}.`);
       return null;
     }
     const existingComment = comments.find((c) => {
@@ -7511,7 +7511,7 @@ function findExistingComment(prNum) {
       return (_a = c.body) == null ? void 0 : _a.startsWith(markupPrefix);
     });
     if (existingComment) {
-      import_core.default.info(`An existing comment (${existingComment.id}) for ${commentId} was found on PR #${prNum} and will be updated.`);
+      import_core.default.info(`An existing comment (${existingComment.id}) for ${commentId} was found on PR #${prNum}.`);
       return existingComment.id;
     }
   });
@@ -7547,9 +7547,10 @@ function createOrUpdateComment(prNums) {
         import_core.default.info("Checking for existing comment on PR....");
         const existingCommentId = yield findExistingComment(prNum);
         if (!createIfNotExists && !existingCommentId) {
-          import_core.default.info("Comment does not exist and will not be created");
+          import_core.default.info("Comment will not be created.");
           return;
         }
+        existingCommentId ? import_core.default.info("Comment will be updated.") : import_core.default.info("Comment will be createed.");
         const body = `${markupPrefix}
 ${commentContent}`;
         const successStatus = existingCommentId ? 200 : 201;

--- a/dist/index.js
+++ b/dist/index.js
@@ -7488,7 +7488,7 @@ var inputPrNum = import_core.default.getInput("pr-number", { required: false, tr
 var prNumber = parseInt(inputPrNum, 10) || (pullRequest == null ? void 0 : pullRequest.number) || 0;
 var commentId = import_core.default.getInput("comment-identifier", requiredArgOptions);
 var commentContent = import_core.default.getInput("comment-content", requiredArgOptions);
-var createIfNotExists = import_core.default.getBooleanInput("comment-content") || true;
+var createIfNotExists = import_core.default.getBooleanInput("comment-content");
 var commentStart = "<!--";
 var commentPackageName = "im-open/update-pr-comment";
 var commentEnd = "-->";

--- a/dist/index.js
+++ b/dist/index.js
@@ -7488,7 +7488,7 @@ var inputPrNum = import_core.default.getInput("pr-number", { required: false, tr
 var prNumber = parseInt(inputPrNum, 10) || (pullRequest == null ? void 0 : pullRequest.number) || 0;
 var commentId = import_core.default.getInput("comment-identifier", requiredArgOptions);
 var commentContent = import_core.default.getInput("comment-content", requiredArgOptions);
-var createIfNotExists = import_core.default.getBooleanInput("comment-content");
+var createIfNotExists = import_core.default.getBooleanInput("create-if-not-exists");
 var commentStart = "<!--";
 var commentPackageName = "im-open/update-pr-comment";
 var commentEnd = "-->";

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ const prNumber = parseInt(inputPrNum, 10) || pullRequest?.number || 0;
 
 const commentId = core.getInput('comment-identifier', requiredArgOptions);
 const commentContent = core.getInput('comment-content', requiredArgOptions);
-const createIfNotExists = core.getBooleanInput('comment-content') || true;
+const createIfNotExists = core.getBooleanInput('comment-content');
 
 const commentStart = '<!--';
 const commentPackageName = 'im-open/update-pr-comment';

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ const prNumber = parseInt(inputPrNum, 10) || pullRequest?.number || 0;
 
 const commentId = core.getInput('comment-identifier', requiredArgOptions);
 const commentContent = core.getInput('comment-content', requiredArgOptions);
-const createIfNotExists = core.getBooleanInput('comment-content');
+const createIfNotExists = core.getBooleanInput('create-if-not-exists');
 
 const commentStart = '<!--';
 const commentPackageName = 'im-open/update-pr-comment';

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,7 @@ async function findExistingComment(prNum: number) {
 
   if (!comments.length) {
     core.info(
-      `An existing comment for ${commentId} was not found on PR #${prNum}, will create a new one instead.`,
+      `An existing comment for ${commentId} was not found on PR #${prNum}.`,
     );
 
     return null;
@@ -45,7 +45,7 @@ async function findExistingComment(prNum: number) {
   const existingComment = comments.find((c) => c.body?.startsWith(markupPrefix));
   if (existingComment) {
     core.info(
-      `An existing comment (${existingComment.id}) for ${commentId} was found on PR #${prNum} and will be updated.`,
+      `An existing comment (${existingComment.id}) for ${commentId} was found on PR #${prNum}.`,
     );
 
     return existingComment.id;
@@ -83,9 +83,13 @@ async function createOrUpdateComment(prNums: number[]) {
       const existingCommentId = await findExistingComment(prNum);
 
       if (!createIfNotExists && !existingCommentId) {
-        core.info('Comment does not exist and will not be created');
+        core.info('Comment will not be created.');
         return;
       }
+      
+      existingCommentId 
+        ? core.info('Comment will be updated.')
+        : core.info('Comment will be createed.')
 
       const body = `${markupPrefix}\n${commentContent}`;
       const successStatus = existingCommentId ? 200 : 201;

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ const prNumber = parseInt(inputPrNum, 10) || pullRequest?.number || 0;
 
 const commentId = core.getInput('comment-identifier', requiredArgOptions);
 const commentContent = core.getInput('comment-content', requiredArgOptions);
+const createIfNotExists = core.getBooleanInput('comment-content') || true;
 
 const commentStart = '<!--';
 const commentPackageName = 'im-open/update-pr-comment';
@@ -80,6 +81,12 @@ async function createOrUpdateComment(prNums: number[]) {
     prNums.forEach(async (prNum) => {
       core.info('Checking for existing comment on PR....');
       const existingCommentId = await findExistingComment(prNum);
+
+      if (!createIfNotExists && !existingCommentId) {
+        core.info('Comment does not exist and will not be created');
+        return;
+      }
+
       const body = `${markupPrefix}\n${commentContent}`;
       const successStatus = existingCommentId ? 200 : 201;
       const infoMessage = existingCommentId

--- a/src/main.ts
+++ b/src/main.ts
@@ -86,10 +86,6 @@ async function createOrUpdateComment(prNums: number[]) {
         core.info('Comment will not be created.');
         return;
       }
-      
-      existingCommentId 
-        ? core.info('Comment will be updated.')
-        : core.info('Comment will be createed.')
 
       const body = `${markupPrefix}\n${commentContent}`;
       const successStatus = existingCommentId ? 200 : 201;


### PR DESCRIPTION
# Summary of PR changes
```
No Comment -> Initial TF plan -> overwrite when regenerating -> New TF plan.
```

Allow to "not" create the comment if an existing comment is missing.

In our terraform workflows, we want to be able to add a comment with the plan results.  Everytime the PR is updated, we update the existing comment.  This is already possible with the action.

When a comment already exists with the terraform plan output on the PR, the user gets confused if the current comment represents the old or new plan after a commit has been pushed up.  There can be up to a 4-5 minute delay as the new commit's plan is ran.

We want to update the existing comment to say the plan is reprocessing, but only if the original plan was added as a commit to the PR.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
